### PR TITLE
Add preload partition on /etc/fstab generation

### DIFF
--- a/extendedcommands.c
+++ b/extendedcommands.c
@@ -1541,6 +1541,7 @@ void create_fstab()
     write_fstab_root("/datadata", file);
     write_fstab_root("/emmc", file);
     write_fstab_root("/system", file);
+    write_fstab_root("/preload", file);
     write_fstab_root("/sdcard", file);
     write_fstab_root("/sd-ext", file);
     write_fstab_root("/external_sd", file);


### PR DESCRIPTION
Now supports 'mount /preload' command in edify and recovery shell
