### PR TITLE
BoardConfig.mk: m7: remove texfat kernel for now

### DIFF
--- a/boardconfig/BoardConfig.mk
+++ b/boardconfig/BoardConfig.mk
@@ -616,7 +616,7 @@ else ifeq ($(TARGET_PRODUCT), cm_pico)
 #HTC One - m7 (m7ul, m7tmo, m7att) / m7spr / m7vzw
 else ifneq ($(filter $(TARGET_PRODUCT), cm_m7 cm_m7spr cm_m7vzw),)
     TARGET_COMMON_NAME := HTC One ($(TARGET_PRODUCT))
-    KERNEL_EXFAT_MODULE_NAME := "texfat"
+    #KERNEL_EXFAT_MODULE_NAME := "texfat"
     TARGET_SCREEN_HEIGHT := 1920
     TARGET_SCREEN_WIDTH := 1080
     BRIGHTNESS_SYS_FILE := "/sys/class/leds/lcd-backlight/brightness"


### PR DESCRIPTION
Switching to cm's msm8960 kernel due to stock HTC kernel
not supporting by-name paths for partitions in fstab
