### PR TITLE
use recovery variant "philz"

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -6,7 +6,7 @@ RECOVERY_VARIANT := philz
 endif
 endif
 
-ifeq ($(RECOVERY_VARIANT),cwm)
+ifeq ($(RECOVERY_VARIANT),philz)
 
 # philz touch gui: either prebuilt or from sources
 PHILZ_TOUCH_RECOVERY := true

--- a/Android.mk
+++ b/Android.mk
@@ -2,7 +2,7 @@ LOCAL_PATH := $(call my-dir)
 
 ifeq ($(RECOVERY_VARIANT),)
 ifeq ($(LOCAL_PATH),bootable/recovery)
-RECOVERY_VARIANT := cwm
+RECOVERY_VARIANT := philz
 endif
 endif
 


### PR DESCRIPTION
So that AOSP builders can keep both cwm and philz in their build path and build any one of them using the options
RECOVERY_VARIANT=cwm
or
RECOVERY_VARIANT=philz
