### PR TITLE
use recovery variant "philz" 

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -6,7 +6,7 @@ RECOVERY_VARIANT := philz
 endif
 endif
 
-ifeq ($(RECOVERY_VARIANT),cwm)
+ifeq ($(RECOVERY_VARIANT),philz)
 
 # philz touch gui: either prebuilt or from sources
 PHILZ_TOUCH_RECOVERY := true

--- a/Android.mk
+++ b/Android.mk
@@ -2,7 +2,7 @@ LOCAL_PATH := $(call my-dir)
 
 ifeq ($(RECOVERY_VARIANT),)
 ifeq ($(LOCAL_PATH),bootable/recovery)
-RECOVERY_VARIANT := cwm
+RECOVERY_VARIANT := philz
 endif
 endif
 


### PR DESCRIPTION
So that AOSP builders can keep both cwm and philz in their build path and build any one of them using the options
RECOVERY_VARIANT=cwm
or
RECOVERY_VARIANT=philz

with
CyanogenMod/android_build@c1b0bb6
and
CyanogenMod/android_build@6b21727
included now, we can have multiple recovery sources inside our build tree like
bootable/recovery-cm
bootable/recovery-twrp
bootable/recovery-philz

like that.

So that while building we can chose which recovery to include (or set separate recoveries for separate devices)
