### PR TITLE
remove hardlink to bootable/recovery path

### DIFF
--- a/libtouch_gui/Android.mk
+++ b/libtouch_gui/Android.mk
@@ -18,7 +18,7 @@ LOCAL_SRC_FILES := touch_gui.c gui_settings.c nandroid_gui.c
 LOCAL_MODULE := libtouch_gui
 
 LOCAL_C_INCLUDES += \
-    bootable/recovery \
+    $(LOCAL_PATH)/.. \
     system/core/fs_mgr/include \
     system/extras/ext4_utils
 


### PR DESCRIPTION
if using multi-recovery system, this recovery might not necessarily be in bootable/recovery folder

it should be rather in bootable/recovery-philz/ folder.
