### PR TITLE
Fix build error caused by 96b499d

### DIFF
--- a/updater/Android.mk
+++ b/updater/Android.mk
@@ -3,7 +3,6 @@
 LOCAL_PATH := $(call my-dir)
 
 updater_src_files := \
-	../mounts.c \
 	install.c \
 	updater.c
 


### PR DESCRIPTION
```
make: *** No rule to make target 'bootable/recovery-philz/updater/../mounts.c', needed by ....
```
