### PR TITLE
Tweak default recovery keys

### DIFF
--- a/default_recovery_keys.c
+++ b/default_recovery_keys.c
@@ -23,12 +23,13 @@ int device_handle_key(int key_code, int visible) {
             case KEY_LEFTBRACE:
             case KEY_ENTER:
             case BTN_MOUSE:
-            case KEY_CAMERA:
             case KEY_F21:
             case KEY_SEND:
             case KEY_HOMEPAGE:
                 return SELECT_ITEM;
-            
+
+            case KEY_CAMERA:
+            case KEY_CAMERA_FOCUS:
             case KEY_END:
             case KEY_BACKSPACE:
             case KEY_SEARCH:


### PR DESCRIPTION
I'm not sure but I think that all devices with camera buttons (KEY_CAMERA or KEY_CAMERA_FOCUS) also have power button (KEY_POWER), so actually we can use additional camera buttons as GO_BACK instead of SELECT_ITEM.

Also add missing KEY_CAMERA_FOCUS used i.e. in Xperia M.
